### PR TITLE
Add unit tests with coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,13 @@ celery periodic tasks.
 7. Start a new terminal tab. Run the command “ python3 manage.py celery worker”
 8. This command starts the celery worker and will start executing the tasks queued in the 
 celery scheduler. 
-9. You can start using the application by going to the link localhost:8000. 
+9. You can start using the application by going to the link localhost:8000.
+
+## Running Tests
+
+To run the test suite with code coverage enabled execute:
+
+```bash
+coverage run manage.py test
+coverage report
+```

--- a/api/tests.py
+++ b/api/tests.py
@@ -14,3 +14,34 @@ class SimpleTest(TestCase):
         Tests that 1 + 1 always equals 2.
         """
         self.assertEqual(1 + 1, 2)
+
+
+class ApiUtilsTest(TestCase):
+    def test_get_random_batch_name(self):
+        from api.views import get_random_batch_name
+        from unittest.mock import patch
+
+        with patch('api.views.random.choice', return_value='B'):
+            name = get_random_batch_name('PREFIX')
+
+        self.assertTrue(name.startswith('PREFIX'))
+        self.assertEqual(name, 'PREFIX' + 'B' * 10)
+
+    def test_status_errors_raise(self):
+        from api.views import status
+
+        class DummyClient:
+            def read_batch_readiness(self, batch_id):
+                return {'errors': ['boom'], 'status': 'bad'}
+
+        with self.assertRaises(Exception):
+            status(DummyClient(), 1)
+
+    def test_status_ok(self):
+        from api.views import status
+
+        class DummyClient:
+            def read_batch_readiness(self, batch_id):
+                return {'errors': [], 'status': 'ready'}
+
+        self.assertEqual(status(DummyClient(), 1), 'ready')

--- a/home/models.py
+++ b/home/models.py
@@ -8,7 +8,14 @@ import random, string
 def get_photo_storage_path(photo_obj, filename):    
      
     random_string = ''.join(random.choice(string.ascii_uppercase + string.digits) for x in range(10))
-    storage_path = 'img/home/' + random_string +"_"+hashlib.sha1(str(photo_obj.user.id)).hexdigest()  +'_' + filename
+    storage_path = (
+        'img/home/'
+        + random_string
+        + "_"
+        + hashlib.sha1(str(photo_obj.user.id).encode('utf-8')).hexdigest()
+        + "_"
+        + filename
+    )
     return storage_path 
 
 

--- a/home/tests.py
+++ b/home/tests.py
@@ -14,3 +14,26 @@ class SimpleTest(TestCase):
         Tests that 1 + 1 always equals 2.
         """
         self.assertEqual(1 + 1, 2)
+
+
+class StoragePathTest(TestCase):
+    def test_get_photo_storage_path(self):
+        from home.models import get_photo_storage_path
+        from django.contrib.auth.models import User
+        from unittest.mock import patch
+        user = User(id=5)
+
+        class Photo:
+            def __init__(self, user):
+                self.user = user
+
+        with patch('home.models.random.choice', return_value='A'):
+            path = get_photo_storage_path(Photo(user), 'example.jpg')
+
+        import hashlib
+        expected_hash = hashlib.sha1(str(user.id).encode()).hexdigest()
+        self.assertTrue(path.startswith('img/home/'))
+        # Ensure the random string length is 10 characters
+        random_part = path.split('/')[-1].split('_')[0]
+        self.assertEqual(random_part, 'A' * 10)
+        self.assertIn('_' + expected_hash + '_example.jpg', path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-debug-toolbar==5.2.0
 django-redis==5.4.0
 Pillow
 redis==6.2.0
+coverage


### PR DESCRIPTION
## Summary
- add coverage dependency
- test helper functions in API and Home apps
- fix sha1 encoding bug
- document how to run coverage

## Testing
- `coverage run manage.py test`
- `coverage report`


------
https://chatgpt.com/codex/tasks/task_e_683f89714f18832c85b1a7b12e9797bf